### PR TITLE
Fix double block execution (for `handle_requirement`)

### DIFF
--- a/lib/bacon/colored_output.rb
+++ b/lib/bacon/colored_output.rb
@@ -4,7 +4,7 @@ module Bacon
       error = yield
 
       print error.empty? ? color("\e[32m") : color("\e[1;31m")
-      super
+      super(*args) { error }
       print color("\e[0m")
     end
 


### PR DESCRIPTION
And double errors output.

# Before

![image](https://cloud.githubusercontent.com/assets/6510020/25067410/6804441c-224b-11e7-8994-6f9029beb47e.png)


# After

*(Log is longer because `bacon` ran from `bundle`)*

![image](https://cloud.githubusercontent.com/assets/6510020/25067413/7c20f288-224b-11e7-931e-1bcb11a05088.png)